### PR TITLE
Fix: ensure_packages(): Requires array given (String)

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -74,7 +74,7 @@ class sudo::package(
       }
     }
     default: {
-      ensure_packages($package)
+      ensure_packages( [$package] )
     }
   }
 }


### PR DESCRIPTION
err: Could not retrieve catalog from remote server: Error 400 on SERVER: ensure_packages(): Requires array given (String) at /etc/puppet/modules/sudo/manifests/package.pp:77 on node 

I was seeing the above error on 2.7.23-1~deb7u3